### PR TITLE
fix code from usage instruction

### DIFF
--- a/usage/index.html
+++ b/usage/index.html
@@ -57,8 +57,8 @@
     <p>Just before the end of your <code>&lt;head&gt;</code>, add this code.</p>
 
 <pre>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/open-fonts@1.1.1/fonts/inter.min.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css">    
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/open-fonts@1.1.1/fonts/inter.min.css"&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css"&gt;
 </pre>
 
     <br>


### PR DESCRIPTION
On Firefox, the usage instruction for CSS file inclusion was empty. Seems like it didn't take the lines verbatim. So I replaced the angle brackets.