### PR TITLE
fix: github link incorrect

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     
     <p>Learn about custom themes on <a href="https://newcss.net/themes/">/themes</a>.</p>
         
-    <p>new.css is fully open source at <a href="https://github.com/xz/fonts">xz/fonts</a> on GitHub.</p>
+    <p>new.css is fully open source at <a href="https://github.com/xz/new.css">xz/new.css</a> on GitHub.</p>
 
     <br>
 


### PR DESCRIPTION
Updated the open source link to point to `xz/new.css` instead of `xz/fonts`